### PR TITLE
Add material isItem check in collecting inv holders

### DIFF
--- a/shared/src/main/java/me/xginko/aef/utils/MaterialUtil.java
+++ b/shared/src/main/java/me/xginko/aef/utils/MaterialUtil.java
@@ -138,6 +138,7 @@ public class MaterialUtil {
             .collect(Collectors.toCollection(() -> EnumSet.noneOf(Material.class)));
 
     public static final Set<Material> INVENTORY_HOLDER_BLOCKS = Arrays.stream(Material.values())
+            .filter(Material::isItem)
             .map(ItemStack::new)
             .filter(itemStack -> itemStack.getItemMeta() instanceof BlockStateMeta)
             .map(itemStack -> ((BlockStateMeta) itemStack.getItemMeta()).getBlockState())


### PR DESCRIPTION
In Paper 1.21, there is an additional check detecting whether material is item in new ItemStack,
so add material#isItem() check before new itemStack operation to fix AEF loading on Paper 1.21.

![image](https://github.com/xGinko/AnarchyExploitFixes/assets/61569423/b4c814da-7ef5-4f4c-bb5d-89d0a88942cf)

isItem() method also exists in paper 1.12.2, so no worry about compatibility : )