### PR TITLE
Replace compileOnly with implementation to eliminate the need for users to download PacketEvents as a plugin.

### DIFF
--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/AnarchyExploitFixes.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/AnarchyExploitFixes.java
@@ -49,7 +49,6 @@ public final class AnarchyExploitFixes extends JavaPlugin {
     private static CachingPermTool cachingPermTool;
     private static ComponentLogger prefixedLogger, unPrefixedLogger;
     private static Metrics metrics;
-    private static boolean isPacketEventsInstalled;
 
     @Override
     public void onLoad() {
@@ -59,36 +58,14 @@ public final class AnarchyExploitFixes extends JavaPlugin {
         // Disable logging for some shaded libraries as those can get very verbose
         String shadedLibs = getClass().getPackageName() + ".libs";
         Configurator.setLevel(shadedLibs + ".reflections.Reflections", Level.OFF);
-        isPacketEventsInstalled = getServer().getPluginManager().getPlugin("packetevents") != null;
-        if (isPacketEventsInstalled) {
-            // Configure and load packetevents
-            PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
-            PacketEvents.getAPI().getSettings().kickOnPacketException(true).reEncodeByDefault(false).checkForUpdates(false);
-            PacketEvents.getAPI().load();
-        }
+        // Configure and load packetevents
+        PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
+        PacketEvents.getAPI().getSettings().kickOnPacketException(true).reEncodeByDefault(false).checkForUpdates(false);
+        PacketEvents.getAPI().load();
     }
 
     @Override
     public void onEnable() {
-        if (!isPacketEventsInstalled) {
-            Stream.of("                                                               ",
-                    "       _   _   _             _   _                             ",
-                    "      / \\ | |_| |_ ___ _ __ | |_(_) ___  _ __                 ",
-                    "     / _ \\| __| __/ _ \\ '_ \\| __| |/ _ \\| '_ \\            ",
-                    "    / ___ \\ |_| ||  __/ | | | |_| | (_) | | | |               ",
-                    "   /_/   \\_\\__|\\__\\___|_| |_|\\__|_|\\___/|_| |_|          ",
-                    "                                                               ",
-                    "   AEF depends on PacketEvents to function!                    ",
-                    "   You can either download the latest release on modrinth:     ",
-                    "   https://modrinth.com/plugin/packetevents/                   ",
-                    "   or choose a dev build on their jenkins:                     ",
-                    "   https://ci.codemc.io/job/retrooper/job/packetevents/        ",
-                    "                                                               "
-            ).forEach(prefixedLogger::error);
-            getServer().getPluginManager().disablePlugin(this);
-            return;
-        }
-
         instance = this;
         cachingPermTool = CachingPermTool.enable(this);
         metrics = new Metrics(this, 8700);
@@ -151,13 +128,12 @@ public final class AnarchyExploitFixes extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        if (isPacketEventsInstalled) {
-            AEFModule.ENABLED_MODULES.forEach(AEFModule::disable);
-            AEFModule.ENABLED_MODULES.clear();
-            AEFListener.LISTENERS.forEach(AEFListener::disable);
-            AEFListener.LISTENERS.clear();
-            PacketEvents.getAPI().terminate();
-        }
+        AEFModule.ENABLED_MODULES.forEach(AEFModule::disable);
+        AEFModule.ENABLED_MODULES.clear();
+        AEFListener.LISTENERS.forEach(AEFListener::disable);
+        AEFListener.LISTENERS.clear();
+        PacketEvents.getAPI().terminate();
+
         if (languageCacheMap != null) {
             languageCacheMap.clear();
             languageCacheMap = null;

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/bedrock/FillNetherCeilingOnChunkload.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/bedrock/FillNetherCeilingOnChunkload.java
@@ -50,6 +50,7 @@ public class FillNetherCeilingOnChunkload extends AEFModule implements Listener 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (!alsoCheckNewChunks && event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
         World world = event.getWorld();
         if (world.getEnvironment() != World.Environment.NETHER) return;
         if (exemptedWorlds.contains(world.getName())) return;

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/bedrock/FillNetherFloorOnChunkload.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/bedrock/FillNetherFloorOnChunkload.java
@@ -50,6 +50,7 @@ public class FillNetherFloorOnChunkload extends AEFModule implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (!alsoCheckNewChunks && event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
         World world = event.getWorld();
         if (world.getEnvironment() != World.Environment.NETHER) return;
         if (exemptedWorlds.contains(world.getName())) return;

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/bedrock/FillOverworldFloorOnChunkload.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/bedrock/FillOverworldFloorOnChunkload.java
@@ -50,6 +50,7 @@ public class FillOverworldFloorOnChunkload extends AEFModule implements Listener
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (!alsoCheckNewChunks && event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
         World world = event.getWorld();
         if (world.getEnvironment() != World.Environment.NETHER) return;
         if (exemptedWorlds.contains(world.getName())) return;

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/chunklimits/DroppedItemLimit.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/chunklimits/DroppedItemLimit.java
@@ -125,6 +125,7 @@ public class DroppedItemLimit extends AEFModule implements Consumer<ScheduledTas
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (!onChunkLoad || event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         int droppedItemCount = 0;
 

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/elytra/ElytraHelper.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/elytra/ElytraHelper.java
@@ -164,5 +164,5 @@ public class ElytraHelper extends AEFModule implements Runnable, PacketListener,
             speedAvg = Math.abs(using3D ? LocationUtil.getRelDistance3D(previous, latest) : LocationUtil.getRelDistance2D(previous, latest)) / tickPeriod;
             previous = latest.clone();
         }
-    };
+    }
 }

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
@@ -122,6 +122,7 @@ public abstract class IllegalItemModule extends AEFModule implements Listener {
                 @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
                 private void onChunkLoad(ChunkLoadEvent event) {
                     if (event.isNewChunk()) return;
+                    if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
                     Chunk chunk = event.getChunk();
                     final int minY = event.getWorld().getMinHeight();

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
@@ -371,7 +371,7 @@ public abstract class IllegalItemModule extends AEFModule implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
         if (listenerCooldowns.get(event.getClass(), createIfAbsent).contains(event.getPlayer().getUniqueId())) {
             event.setCancelled(true);

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
@@ -371,7 +371,7 @@ public abstract class IllegalItemModule extends AEFModule implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
     public void onPlayerInteract(PlayerInteractEvent event) {
         if (listenerCooldowns.get(event.getClass(), createIfAbsent).contains(event.getPlayer().getUniqueId())) {
             event.setCancelled(true);

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/placedblocks/RemoveIllegalBlocksOnChunkload.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/placedblocks/RemoveIllegalBlocksOnChunkload.java
@@ -71,6 +71,7 @@ public class RemoveIllegalBlocksOnChunkload extends AEFModule implements Listene
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk()) return;
         if (checkShouldPauseOnLowTPS && AnarchyExploitFixes.getTickReporter().getTPS() <= pauseTPS) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         Chunk chunk = event.getChunk();
         World world = chunk.getWorld();

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/placedblocks/RemoveUnnaturalSpawners.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/illegals/placedblocks/RemoveUnnaturalSpawners.java
@@ -87,6 +87,7 @@ public class RemoveUnnaturalSpawners extends AEFModule implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk() || checkShouldPauseOnLowTPS && AnarchyExploitFixes.getTickReporter().getTPS() <= pauseTPS) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         Chunk chunk = event.getChunk();
         World world = chunk.getWorld();

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/lagpreventions/KeepStashLoaded.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/lagpreventions/KeepStashLoaded.java
@@ -143,6 +143,7 @@ public class KeepStashLoaded extends AEFModule implements Consumer<ScheduledTask
         if (event.isNewChunk()) return;
         final String world = event.getWorld().getName();
         if (!worldsAndTheirRadiuses.containsKey(world)) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         Chunk chunk = event.getChunk();
 

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/lagpreventions/agelimits/CustomAgeLimits.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/lagpreventions/agelimits/CustomAgeLimits.java
@@ -114,6 +114,7 @@ public class CustomAgeLimits extends AEFModule implements Consumer<ScheduledTask
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         for (Entity entity : event.getChunk().getEntities()) {
             if (entityLimits.containsKey(entity.getType()) && entity.getTicksLived() >= entityLimits.get(entity.getType())) {

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/packets/MapCursorLag.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/packets/MapCursorLag.java
@@ -58,6 +58,7 @@ public class MapCursorLag extends PacketModule implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         for (Entity entity : event.getChunk().getEntities()) {
             if (EntityUtil.ITEM_FRAMES.contains(entity.getType())) {

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/preventions/withers/RemoveSkullsOnChunkload.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/preventions/withers/RemoveSkullsOnChunkload.java
@@ -36,6 +36,7 @@ public class RemoveSkullsOnChunkload extends AEFModule implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         for (Entity entity : event.getChunk().getEntities()) {
             if (entity.getType() == XEntityType.WITHER_SKULL.get()) {

--- a/AnarchyExploitFixesFolia/src/main/resources/plugin.yml
+++ b/AnarchyExploitFixesFolia/src/main/resources/plugin.yml
@@ -4,8 +4,6 @@ version: ${version}
 main: me.xginko.aef.AnarchyExploitFixes
 authors: [ xGinko, moo ]
 description: ${description}
-softdepend:
-  - packetevents
 api-version: '1.19'
 folia-supported: true
 website: ${url}

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/AnarchyExploitFixes.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/AnarchyExploitFixes.java
@@ -49,7 +49,6 @@ public final class AnarchyExploitFixes extends JavaPlugin {
     private static CachingPermTool cachingPermTool;
     private static Logger prefixedLogger, unPrefixedLogger;
     private static Metrics metrics;
-    private static boolean isPacketEventsInstalled;
 
     @Override
     public void onLoad() {
@@ -64,36 +63,15 @@ public final class AnarchyExploitFixes extends JavaPlugin {
         Configurator.setLevel(shadedLibs + ".zaxxer.hikari.HikariDataSource", Level.OFF);
         Configurator.setLevel(shadedLibs + ".zaxxer.hikari.HikariConfig", Level.OFF);
         Configurator.setLevel(shadedLibs + ".zaxxer.hikari.util.DriverDataSource", Level.OFF);
-        isPacketEventsInstalled = getServer().getPluginManager().getPlugin("packetevents") != null;
-        if (isPacketEventsInstalled) {
-            // Configure and load packetevents
-            PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
-            PacketEvents.getAPI().getSettings().kickOnPacketException(true).reEncodeByDefault(false).checkForUpdates(false);
-            PacketEvents.getAPI().load();
-        }
+
+        // Configure and load packetevents
+        PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
+        PacketEvents.getAPI().getSettings().kickOnPacketException(true).reEncodeByDefault(false).checkForUpdates(false);
+        PacketEvents.getAPI().load();
     }
 
     @Override
     public void onEnable() {
-        if (!isPacketEventsInstalled) {
-            Stream.of("                                                               ",
-                    "       _   _   _             _   _                             ",
-                    "      / \\ | |_| |_ ___ _ __ | |_(_) ___  _ __                 ",
-                    "     / _ \\| __| __/ _ \\ '_ \\| __| |/ _ \\| '_ \\            ",
-                    "    / ___ \\ |_| ||  __/ | | | |_| | (_) | | | |               ",
-                    "   /_/   \\_\\__|\\__\\___|_| |_|\\__|_|\\___/|_| |_|          ",
-                    "                                                               ",
-                    "   AEF depends on PacketEvents to function!                    ",
-                    "   You can either download the latest release on modrinth:     ",
-                    "   https://modrinth.com/plugin/packetevents/                   ",
-                    "   or choose a dev build on their jenkins:                     ",
-                    "   https://ci.codemc.io/job/retrooper/job/packetevents/        ",
-                    "                                                               "
-            ).forEach(prefixedLogger::error);
-            getServer().getPluginManager().disablePlugin(this);
-            return;
-        }
-
         instance = this;
         cachingPermTool = CachingPermTool.enable(this);
         metrics = new Metrics(this, 8700);
@@ -154,11 +132,10 @@ public final class AnarchyExploitFixes extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        if (isPacketEventsInstalled) {
-            AEFModule.ENABLED_MODULES.forEach(AEFModule::disable);
-            AEFModule.ENABLED_MODULES.clear();
-            PacketEvents.getAPI().terminate();
-        }
+        AEFModule.ENABLED_MODULES.forEach(AEFModule::disable);
+        AEFModule.ENABLED_MODULES.clear();
+        PacketEvents.getAPI().terminate();
+
         if (languageCacheMap != null) {
             languageCacheMap.clear();
             languageCacheMap = null;

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/bedrock/FillNetherCeilingOnChunkload.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/bedrock/FillNetherCeilingOnChunkload.java
@@ -54,6 +54,7 @@ public class FillNetherCeilingOnChunkload extends AEFModule implements Listener 
         final World world = event.getWorld();
         if (world.getEnvironment() != World.Environment.NETHER) return;
         if (exemptedWorlds.contains(world.getName())) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         if (!pauseOnLowTPS || AnarchyExploitFixes.getTickReporter().getTPS() >= pauseTPS) {
             ChunkUtil.createBedrockLayer(event.getChunk(), config.nether_ceiling_max_y);

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/bedrock/FillNetherFloorOnChunkload.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/bedrock/FillNetherFloorOnChunkload.java
@@ -54,6 +54,7 @@ public class FillNetherFloorOnChunkload extends AEFModule implements Listener {
         if (world.getEnvironment() != World.Environment.NETHER) return;
         if (exemptedWorlds.contains(world.getName())) return;
         if (!alsoCheckNewChunks && event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         if (!pauseOnLowTPS || AnarchyExploitFixes.getTickReporter().getTPS() >= pauseTPS) {
             ChunkUtil.createBedrockLayer(event.getChunk(), WorldUtil.getMinWorldHeight(world));

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/bedrock/FillOverworldFloorOnChunkload.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/bedrock/FillOverworldFloorOnChunkload.java
@@ -54,6 +54,7 @@ public class FillOverworldFloorOnChunkload extends AEFModule implements Listener
         final World world = event.getWorld();
         if (world.getEnvironment() != World.Environment.NORMAL) return;
         if (exemptedWorlds.contains(world.getName())) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         if (!pauseOnLowTPS || AnarchyExploitFixes.getTickReporter().getTPS() >= pauseTPS) {
             ChunkUtil.createBedrockLayer(event.getChunk(), WorldUtil.getMinWorldHeight(world));

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/chunklimits/DroppedItemLimit.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/chunklimits/DroppedItemLimit.java
@@ -121,6 +121,7 @@ public class DroppedItemLimit extends AEFModule implements Listener, Runnable {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (!onChunkLoad || event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         int droppedItemCount = 0;
 

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/elytra/ElytraHelper.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/elytra/ElytraHelper.java
@@ -180,6 +180,8 @@ public class ElytraHelper extends AEFModule implements Runnable, PacketListener,
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         private void onChunkLoad(ChunkLoadEvent event) {
+            if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
+
             for (Player player : event.getWorld().getPlayers()) {
                 if (ChunkUtil.getChunkDistanceSquared(event.getChunk(), player.getLocation()) < NumberConversions.square(player.getViewDistance())) {
                     if (event.isNewChunk()) {

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
@@ -122,6 +122,7 @@ public abstract class IllegalItemModule extends AEFModule implements Listener {
                 @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
                 private void onChunkLoad(ChunkLoadEvent event) {
                     if (event.isNewChunk()) return;
+                    if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
                     Chunk chunk = event.getChunk();
                     final int minY = WorldUtil.getMinWorldHeight(event.getWorld());

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
@@ -347,7 +347,7 @@ public abstract class IllegalItemModule extends AEFModule implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
     public void onPlayerInteract(PlayerInteractEvent event) {
         if (listenerCooldowns.get(event.getClass(), createIfAbsent).contains(event.getPlayer().getUniqueId())) {
             event.setCancelled(true);

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/items/IllegalItemModule.java
@@ -347,7 +347,7 @@ public abstract class IllegalItemModule extends AEFModule implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
         if (listenerCooldowns.get(event.getClass(), createIfAbsent).contains(event.getPlayer().getUniqueId())) {
             event.setCancelled(true);

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/placedblocks/RemoveIllegalBlocksOnChunkload.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/placedblocks/RemoveIllegalBlocksOnChunkload.java
@@ -82,6 +82,7 @@ public class RemoveIllegalBlocksOnChunkload extends AEFModule implements Listene
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk() || (checkShouldPauseOnLowTPS && AnarchyExploitFixes.getTickReporter().getTPS() <= pauseTPS)) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         Chunk chunk = event.getChunk();
         World world = chunk.getWorld();

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/placedblocks/RemoveUnnaturalSpawners.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/illegals/placedblocks/RemoveUnnaturalSpawners.java
@@ -88,6 +88,7 @@ public class RemoveUnnaturalSpawners extends AEFModule implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk() || checkShouldPauseOnLowTPS && AnarchyExploitFixes.getTickReporter().getTPS() <= pauseTPS) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         Chunk chunk = event.getChunk();
         World world = chunk.getWorld();

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/lagpreventions/KeepStashLoaded.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/lagpreventions/KeepStashLoaded.java
@@ -139,6 +139,8 @@ public class KeepStashLoaded extends AEFModule implements Runnable, Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
+
         final String world = event.getWorld().getName();
         if (!worldsAndTheirRadiuses.containsKey(world)) return;
 

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/lagpreventions/agelimits/CustomAgeLimits.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/lagpreventions/agelimits/CustomAgeLimits.java
@@ -96,6 +96,7 @@ public class CustomAgeLimits extends AEFModule implements Runnable, Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         for (Entity entity : event.getChunk().getEntities()) {
             if (entityLimits.containsKey(entity.getType()) && entity.getTicksLived() >= entityLimits.get(entity.getType())) {

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/packets/MapCursorLag.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/packets/MapCursorLag.java
@@ -58,6 +58,7 @@ public class MapCursorLag extends PacketModule implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         for (Entity entity : event.getChunk().getEntities()) {
             if (EntityUtil.ITEM_FRAMES.contains(entity.getType())) {

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/preventions/MapSpam.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/preventions/MapSpam.java
@@ -59,7 +59,7 @@ public class MapSpam extends AEFModule implements Listener {
         HandlerList.unregisterAll(this);
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    @EventHandler(priority = EventPriority.HIGHEST)
     private void onPlayerInteract(PlayerInteractEvent event) {
         if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) return;
         final ItemStack mapItem = event.getItem();

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/preventions/MapSpam.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/preventions/MapSpam.java
@@ -59,7 +59,7 @@ public class MapSpam extends AEFModule implements Listener {
         HandlerList.unregisterAll(this);
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
     private void onPlayerInteract(PlayerInteractEvent event) {
         if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) return;
         final ItemStack mapItem = event.getItem();

--- a/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/preventions/withers/RemoveSkullsOnChunkload.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/xginko/aef/modules/preventions/withers/RemoveSkullsOnChunkload.java
@@ -36,6 +36,7 @@ public class RemoveSkullsOnChunkload extends AEFModule implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     private void onChunkLoad(ChunkLoadEvent event) {
         if (event.isNewChunk()) return;
+        if (event.getChunk().getX() > 1875000 || event.getChunk().getZ() > 1875000 || event.getChunk().getX() < -1875000 || event.getChunk().getZ() < -1875000) return;
 
         for (Entity entity : event.getChunk().getEntities()) {
             if (entity.getType() == XEntityType.WITHER_SKULL.get()) {

--- a/AnarchyExploitFixesLegacy/src/main/resources/plugin.yml
+++ b/AnarchyExploitFixesLegacy/src/main/resources/plugin.yml
@@ -4,8 +4,6 @@ version: ${version}
 main: me.xginko.aef.AnarchyExploitFixes
 authors: [ xGinko, moo ]
 description: ${description}
-softdepend:
-  - packetevents
 api-version: '1.13'
 folia-supported: false
 website: ${url}

--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ new-places.ru (5-20), mc.arch.lol (500-600)
 ## Downloads
 Downloads can be obtained from the [modrinth page](https://modrinth.com/plugin/anarchyexploitfixes) or the [actions tab](https://github.com/xGinko/AnarchyExploitFixes/actions/workflows/gradle.yml).
 
-## Requirements
-
-* [PacketEvents](https://github.com/retrooper/packetevents) - To be able to prevent packet exploits. Without it, the plugin cannot enable.
-
 ## Building from source
 
 First, <u>clone</u> this repository.

--- a/build-logic/src/main/kotlin/me.xginko.aef.wrapper.gradle.kts
+++ b/build-logic/src/main/kotlin/me.xginko.aef.wrapper.gradle.kts
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.github.retrooper:packetevents-spigot:2.4.0") // PacketEvents to patch packet based exploits
+    implementation("com.github.retrooper:packetevents-spigot:2.5.1-SNAPSHOT") // PacketEvents to patch packet based exploits
     api("com.github.cryptomorin:XSeries:11.2.0.1") // Crossversion entitytype and material support
     api("com.github.thatsmusic99:ConfigurationMaster-API:v2.0.0-rc.1") // ConfigurationMaster for enhanced config management
     api("de.tr7zw:item-nbt-api:2.13.2") // NBT API for cross version nbt tag handling


### PR DESCRIPTION
Replace compileOnly with implementation to eliminate the need for users to download PacketEvents as a plugin.