### PR TITLE
Remove unnecessary downcast to float

### DIFF
--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/elytra/ElytraHelper.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/elytra/ElytraHelper.java
@@ -162,16 +162,16 @@ public class ElytraHelper extends AEFModule implements Runnable, PacketListener,
         }
 
         public void updateLatestPosition(com.github.retrooper.packetevents.protocol.world.Location location) {
-            latest.setX((float) location.getX());
-            latest.setY((float) location.getY());
-            latest.setZ((float) location.getZ());
+            latest.setX(location.getX());
+            latest.setY(location.getY());
+            latest.setZ(location.getZ());
         }
 
         public void updateLatestPosition(Location location) {
             latest.setWorld(location.getWorld());
-            latest.setX((float) location.getX());
-            latest.setY((float) location.getY());
-            latest.setZ((float) location.getZ());
+            latest.setX(location.getX());
+            latest.setY(location.getY());
+            latest.setZ(location.getZ());
         }
 
         public void calcSpeedAvg(boolean using3D, long tickPeriod) {


### PR DESCRIPTION
Removes an unnecessary downcast from a double to a float, which loses precision at higher powers of two.