### PR TITLE
Split config into multiple files for better clarity and easier management.

### DIFF
--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/AnarchyExploitFixes.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/AnarchyExploitFixes.java
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import de.tr7zw.nbtapi.NBT;
 import me.xginko.aef.commands.AEFCommand;
 import me.xginko.aef.config.Config;
+import me.xginko.aef.config.ConfigMigration;
 import me.xginko.aef.config.Translation;
 import me.xginko.aef.modules.AEFModule;
 import me.xginko.aef.utils.KyoriUtil;
@@ -164,6 +165,13 @@ public final class AnarchyExploitFixes extends JavaPlugin {
 
         prefixedLogger.info("Registering Permissions");
         AEFPermission.registerAll();
+
+        prefixedLogger.info("Checking for config migration");
+        ConfigMigration configMigration = new ConfigMigration(this);
+        boolean migrated = configMigration.migrateIfNeeded();
+        if (migrated) {
+            prefixedLogger.info("Config migration completed successfully!");
+        }
 
         prefixedLogger.info("Loading Config");
         reloadConfiguration();

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/config/Config.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/config/Config.java
@@ -3,6 +3,7 @@ package me.xginko.aef.config;
 import com.cryptomorin.xseries.XSound;
 import io.github.thatsmusic99.configurationmaster.api.ConfigFile;
 import io.github.thatsmusic99.configurationmaster.api.ConfigSection;
+import io.github.thatsmusic99.configurationmaster.impl.CMMemorySection;
 import me.xginko.aef.AnarchyExploitFixes;
 import me.xginko.aef.utils.LocaleUtil;
 import me.xginko.aef.utils.MathUtil;
@@ -12,13 +13,17 @@ import org.bukkit.Sound;
 
 import java.io.File;
 import java.time.Duration;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 public class Config {
 
-    private final ConfigFile config;
+    private final AnarchyExploitFixes plugin;
+    private final HashMap<String, ConfigFile> configFiles = new HashMap<>();
+    private static final Set<String> configSections = new HashSet<>(Arrays.asList(
+            "language", "general", "misc", "chat", "elytra",
+            "chunk-limits", "lag-preventions", "patches", "illegals",
+            "dupe-preventions", "preventions", "combat"
+    ));
     public final Locale default_lang;
     public final Sound elytra_too_fast_sound;
     public final Component cmd_say_format;
@@ -33,16 +38,28 @@ public class Config {
             elytra_actionbar_enabled, elytra_show_chunkage, elytra_play_too_fast_sound,
             elytra_teleport_back, elytra_calculate_3D, permissions_hook, update_checker_enabled;
 
+    public static Set<String> getConfigSections() {
+        return Collections.unmodifiableSet(configSections);
+    }
+
     public Config() throws Exception {
-        AnarchyExploitFixes plugin = AnarchyExploitFixes.getInstance();
-        // Load config.yml with ConfigMaster
-        this.config = ConfigFile.loadConfig(new File(plugin.getDataFolder(), "config.yml"));
+        this.plugin = AnarchyExploitFixes.getInstance();
 
-        config.set("plugin-version", plugin.getPluginMeta().getVersion());
-        config.set("server-version", plugin.getServer().getVersion());
+        File settingsDir = new File(plugin.getDataFolder(), "settings");
+        if (!settingsDir.exists()) {
+            settingsDir.mkdirs();
+        }
 
-        // Pre-structure to force order
-        structureConfig();
+        // Initialize all config files
+        initConfigFile("config");
+        for (String section : configSections) {
+            initConfigFile("settings/" + section);
+        }
+
+        loadAllConfigs();
+
+        getConfig("config").set("plugin-version", plugin.getPluginMeta().getVersion());
+        getConfig("config").set("server-version", plugin.getServer().getVersion());
 
         // Language Settings
         this.default_lang = LocaleUtil.localeForLanguageTag(getString("language.default-language", "en_us", """
@@ -76,7 +93,7 @@ public class Config {
                 Help command that shows a small command overview for players.""");
         this.cmd_toggleConMsgs_enabled = getBoolean("general.commands.toggleconnectionmsgs.enable", true, """
                 If you don't use join leave/messages, you can set this to false.""");
-        config.addComment("general.commands", """
+        addComment("general.commands", """
                 A server restart is required when changing a command's enable status!""");
 
         // Elytra Speed
@@ -115,121 +132,167 @@ public class Config {
         this.elytra_enable_netherceiling = getBoolean("elytra.elytra-speed.Nether-Ceiling.enable", true);
 
         // Misc
-        config.addDefault("misc.join-leave-messages.enable", true); // add default here so enable option shows up first.
+        addDefault("misc.join-leave-messages.enable", true); // add default here so enable option shows up first.
         this.connectionMsgsAreOnByDefault = getBoolean("misc.join-leave-messages.connection-messages-on-by-default", true, """
                 If set to true, players will see join/leave messages by default\s
                 and enter /toggleconnectionmsgs to disable them.\s
                 If set to false will work the other way around.""");
-        config.addDefault("misc.join-leave-messages.show-in-console", false); // add default here so show-in-console option is not misplaced.
+        addDefault("misc.join-leave-messages.show-in-console", false); // add default here so show-in-console option is not misplaced.
+
+        saveAllConfigs();
+    }
+
+    private void initConfigFile(String name) throws Exception {
+        ConfigFile configFile = ConfigFile.loadConfig(new File(plugin.getDataFolder(), name + ".yml"));
+        configFiles.put(name, configFile);
+    }
+
+    private ConfigFile getConfig(String name) {
+        return configFiles.getOrDefault(name, null);
     }
 
     public void saveConfig() {
         try {
-            config.save();
+            saveAllConfigs();
         } catch (Exception e) {
-            AnarchyExploitFixes.prefixedLogger().error("Failed to save config file!", e);
+            AnarchyExploitFixes.prefixedLogger().error("Failed to save config files!", e);
         }
     }
 
-    private void structureConfig() {
-        createTitledSection("Language", "language");
-        createTitledSection("General", "general");
-        createTitledSection("Miscellaneous", "misc");
-        createTitledSection("Chat", "chat");
-        createTitledSection("Elytra", "elytra");
-        createTitledSection("Chunk Limits", "chunk-limits");
-        createTitledSection("Lag Preventions", "lag-preventions");
-        createTitledSection("Patches", "patches");
-        createTitledSection("Illegals", "illegals");
-        createTitledSection("Dupe Preventions", "dupe-preventions");
-        createTitledSection("Preventions", "preventions");
-        createTitledSection("Combat", "combat");
+    private void loadAllConfigs() {
+        for (ConfigFile config : configFiles.values()) {
+            try {
+                config.load();
+            } catch (Exception e) {
+                AnarchyExploitFixes.prefixedLogger().error("Failed to load config file!", e);
+            }
+        }
     }
 
-    public ConfigFile master() {
-        return config;
+    private void saveAllConfigs() {
+        for (ConfigFile config : configFiles.values()) {
+            try {
+                config.save();
+            } catch (Exception e) {
+                AnarchyExploitFixes.prefixedLogger().error("Failed to save config file!", e);
+            }
+        }
+    }
+    
+    private String[] getConfigNameAndPath(String path) {
+        if (!path.contains(".")) {
+            return new String[]{"config", path};
+        }
+        
+        String section = path.substring(0, path.indexOf("."));
+        String newPath = path.substring(path.indexOf(".") + 1);
+        
+        if (configSections.contains(section)) {
+            return new String[]{"settings/" + section, newPath};
+        } else {
+            return new String[]{"config", path};
+        }
     }
 
-    public void createTitledSection(String title, String path) {
-        config.addSection(title);
-        config.addDefault(path, null);
+    private <T> T getConfigValue(String path, T defaultValue, String comment, ConfigValueGetter<T> getter) {
+        String[] configAndPath = getConfigNameAndPath(path);
+        ConfigFile config = getConfig(configAndPath[0]);
+        if (config == null) return defaultValue;
+        
+        if (comment != null) {
+            config.addDefault(configAndPath[1], defaultValue, comment);
+        } else {
+            config.addDefault(configAndPath[1], defaultValue);
+        }
+        
+        return getter.get(config, configAndPath[1], defaultValue);
     }
 
     public boolean getBoolean(String path, boolean def, String comment) {
-        config.addDefault(path, def, comment);
-        return config.getBoolean(path, def);
+        return getConfigValue(path, def, comment, CMMemorySection::getBoolean);
     }
 
     public boolean getBoolean(String path, boolean def) {
-        config.addDefault(path, def);
-        return config.getBoolean(path, def);
+        return getConfigValue(path, def, null, CMMemorySection::getBoolean);
     }
 
     public String getString(String path, String def, String comment) {
-        config.addDefault(path, def, comment);
-        return config.getString(path, def);
+        return getConfigValue(path, def, comment, CMMemorySection::getString);
     }
 
     public String getString(String path, String def) {
-        config.addDefault(path, def);
-        return config.getString(path, def);
+        return getConfigValue(path, def, null, CMMemorySection::getString);
     }
 
     public double getDouble(String path, double def, String comment) {
-        config.addDefault(path, def, comment);
-        return config.getDouble(path, def);
+        return getConfigValue(path, def, comment, CMMemorySection::getDouble);
     }
 
     public double getDouble(String path, double def) {
-        config.addDefault(path, def);
-        return config.getDouble(path, def);
+        return getConfigValue(path, def, null, CMMemorySection::getDouble);
     }
 
     public int getInt(String path, int def, String comment) {
-        config.addDefault(path, def, comment);
-        return config.getInteger(path, def);
+        return getConfigValue(path, def, comment, CMMemorySection::getInteger);
     }
 
     public int getInt(String path, int def) {
-        config.addDefault(path, def);
-        return config.getInteger(path, def);
+        return getConfigValue(path, def, null, CMMemorySection::getInteger);
     }
 
     public long getLong(String path, long def, String comment) {
-        config.addDefault(path, def, comment);
-        return config.getLong(path, def);
+        return getConfigValue(path, def, comment, CMMemorySection::getLong);
     }
 
     public long getLong(String path, long def) {
-        config.addDefault(path, def);
-        return config.getLong(path, def);
+        return getConfigValue(path, def, null, CMMemorySection::getLong);
     }
 
     public List<String> getList(String path, List<String> def, String comment) {
-        config.addDefault(path, def, comment);
-        return config.getStringList(path);
+        return getConfigValue(path, def, comment, (config, p, d) -> config.getStringList(p));
     }
 
     public List<String> getList(String path, List<String> def) {
-        config.addDefault(path, def);
-        return config.getStringList(path);
+        return getConfigValue(path, def, null, (config, p, d) -> config.getStringList(p));
     }
 
     public ConfigSection getConfigSection(String path, Map<String, Object> defaultKeyValue) {
-        config.addDefault(path, null);
-        config.makeSectionLenient(path);
-        defaultKeyValue.forEach((string, object) -> config.addExample(path+"."+string, object));
-        return config.getConfigSection(path);
+        String[] configAndPath = getConfigNameAndPath(path);
+        ConfigFile config = getConfig(configAndPath[0]);
+        if (config == null) return null;
+        config.addDefault(configAndPath[1], null);
+        config.makeSectionLenient(configAndPath[1]);
+        defaultKeyValue.forEach((string, object) -> config.addExample(configAndPath[1] + "." + string, object));
+        return config.getConfigSection(configAndPath[1]);
     }
 
     public ConfigSection getConfigSection(String path, Map<String, Object> defaultKeyValue, String comment) {
-        config.addDefault(path, null, comment);
-        config.makeSectionLenient(path);
-        defaultKeyValue.forEach((string, object) -> config.addExample(path+"."+string, object));
-        return config.getConfigSection(path);
+        String[] configAndPath = getConfigNameAndPath(path);
+        ConfigFile config = getConfig(configAndPath[0]);
+        if (config == null) return null;
+        config.addDefault(configAndPath[1], null, comment);
+        config.makeSectionLenient(configAndPath[1]);
+        defaultKeyValue.forEach((string, object) -> config.addExample(configAndPath[1] + "." + string, object));
+        return config.getConfigSection(configAndPath[1]);
     }
 
     public void addComment(String path, String comment) {
-        config.addComment(path, comment);
+        String[] configAndPath = getConfigNameAndPath(path);
+        ConfigFile config = getConfig(configAndPath[0]);
+        if (config != null) {
+            config.addComment(configAndPath[1], comment);
+        }
+    }
+
+    public void addDefault(String path, Object value) {
+        String[] configAndPath = getConfigNameAndPath(path);
+        ConfigFile config = getConfig(configAndPath[0]);
+        if (config != null) {
+            config.addDefault(configAndPath[1], value);
+        }
+    }
+
+    private interface ConfigValueGetter<T> {
+        T get(ConfigFile config, String path, T defaultValue);
     }
 }

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/config/ConfigMigration.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/config/ConfigMigration.java
@@ -1,0 +1,100 @@
+package me.xginko.aef.config;
+
+import io.github.thatsmusic99.configurationmaster.api.ConfigFile;
+import io.github.thatsmusic99.configurationmaster.api.ConfigSection;
+import me.xginko.aef.AnarchyExploitFixes;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+public class ConfigMigration {
+
+    private final AnarchyExploitFixes plugin;
+    private final File oldConfigFile;
+    private ConfigFile oldConfig;
+    private boolean needsMigration = false;
+
+    public ConfigMigration(AnarchyExploitFixes plugin) {
+        this.plugin = plugin;
+        this.oldConfigFile = new File(plugin.getDataFolder(), "config.yml");
+    }
+
+    public boolean migrateIfNeeded() {
+        if (!oldConfigFile.exists()) {
+            return false;
+        }
+
+        try {
+            this.oldConfig = ConfigFile.loadConfig(oldConfigFile);
+
+            Set<String> sections = Config.getConfigSections();
+            for (String section : sections) {
+                if (oldConfig.contains(section) && oldConfig.get(section) != null) {
+                    needsMigration = true;
+                    break;
+                }
+            }
+
+            if (!needsMigration) {
+                return false;
+            }
+
+            File settingsDir = new File(plugin.getDataFolder(), "settings");
+            if (!settingsDir.exists()) {
+                settingsDir.mkdirs();
+            }
+
+            plugin.getLogger().info("Migrating config from single file to multi-file format...");
+
+            for (String section : sections) {
+                migrateSection(section);
+            }
+
+            File backupFile = new File(plugin.getDataFolder(), "config.yml.old");
+            if (backupFile.exists()) {
+                backupFile.delete();
+            }
+            oldConfigFile.renameTo(backupFile);
+
+            ConfigFile newMainConfig = ConfigFile.loadConfig(oldConfigFile);
+            newMainConfig.set("plugin-version", plugin.getPluginMeta().getVersion());
+            newMainConfig.set("server-version", plugin.getServer().getVersion());
+            newMainConfig.save();
+            return true;
+
+        } catch (Exception e) {
+            plugin.getLogger().severe("Failed to migrate config: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private void migrateSection(String sectionName) throws Exception {
+        if (!oldConfig.contains(sectionName)) {
+            return;
+        }
+
+        File sectionFile = new File(plugin.getDataFolder(), "settings/" + sectionName + ".yml");
+        ConfigFile sectionConfig = ConfigFile.loadConfig(sectionFile);
+
+        ConfigSection section = oldConfig.getConfigSection(sectionName);
+        if (section != null) {
+            List<String> keys = section.getKeys(true);
+
+            for (String key : keys) {
+                if (section.getConfigSection(key) != null) {
+                    continue;
+                }
+
+                Object value = section.get(key);
+                if (value != null) {
+                    sectionConfig.set(key, value);
+                }
+            }
+        }
+
+        sectionConfig.save();
+        plugin.getLogger().info("Migrated section: " + sectionName);
+    }
+}

--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/preventions/HeightLimits.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/preventions/HeightLimits.java
@@ -68,20 +68,20 @@ public class HeightLimits extends AEFModule implements Listener {
         this.fillMaterial = filler_material;
 
         String sectionPath = configPath + ".worlds";
-        config.master().makeSectionLenient(sectionPath);
-        config.master().addExample(sectionPath + ".world.y-limit.upper", 500);
-        config.master().addExample(sectionPath + ".world.y-limit.lower", -64);
-        config.master().addExample(sectionPath + ".world_nether.y-limit.upper", 127);
-        config.master().addExample(sectionPath + ".world_nether.y-limit.lower", 0);
-        config.master().addExample(sectionPath + ".world_the_end.y-limit.upper", 500);
-        config.master().addExample(sectionPath + ".world_the_end.y-limit.lower", 0);
-        ConfigSection limitsSection = config.master().getConfigSection(sectionPath);
+        Map<String, Object> defaults = new HashMap<>();
+        defaults.put("world.y-limit.upper", 500);
+        defaults.put("world.y-limit.lower", -64);
+        defaults.put("world_nether.y-limit.upper", 127);
+        defaults.put("world_nether.y-limit.lower", 0);
+        defaults.put("world_the_end.y-limit.upper", 500);
+        defaults.put("world_the_end.y-limit.lower", 0);
+        ConfigSection limitsSection = config.getConfigSection(sectionPath, defaults);
         List<String> worlds = limitsSection.getKeys(false);
         worldHeightLimits = new HashMap<>(worlds.size());
         for (String world : worlds) {
             this.worldHeightLimits.put(world, new WorldHeightLimit(
-                    config.master().getInteger(sectionPath + "." + world + ".y-limit.upper", 500),
-                    config.master().getInteger(sectionPath + "." + world + ".y-limit.lower", 0)
+                    config.getInt(sectionPath + "." + world + ".y-limit.upper", 500),
+                    config.getInt(sectionPath + "." + world + ".y-limit.lower", 0)
             ));
         }
     }


### PR DESCRIPTION
# Multi-file Configuration System

This PR implements a multi-file configuration system that splits the large monolithic config.yml into separate files by section.
This implements the enhancement requested in issue #276.

## Changes

- Created a new directory structure with `settings/` folder containing section-specific config files
- Modified the `Config` class to support loading/saving from multiple files while maintaining backward compatibility
- Added a `ConfigMigration` class to automatically migrate existing configs to the new format
- Updated modules to work with the new config system

## Technical Details

- The config is now split into these files:
  - `config.yml` (main config with version info)
  - `settings/language.yml`
  - `settings/general.yml`
  - `settings/misc.yml`
  - `settings/chat.yml`
  - `settings/elytra.yml`
  - `settings/chunk-limits.yml`
  - `settings/lag-preventions.yml`
  - `settings/patches.yml`
  - `settings/illegals.yml`
  - `settings/dupe-preventions.yml`
  - `settings/preventions.yml`
  - `settings/combat.yml`

- Old configs are automatically backed up before migration

## Implementation Note

I decided to maintain the existing path format in code (e.g., `elytra.elytra-speed.play-sound-when-too-fast`) instead of changing to a new format like `("settings/elytra", "elytra-speed.play-sound-when-too-fast")` to minimize code changes throughout the plugin. The Config class automatically maps these paths to the appropriate files internally.

If you prefer a different approach or have any suggestions for improvements, please let me know!