### PR TITLE
Do not copy tile entities on keep stash loaded scan

### DIFF
--- a/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/lagpreventions/KeepStashLoaded.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/xginko/aef/modules/lagpreventions/KeepStashLoaded.java
@@ -168,7 +168,7 @@ public class KeepStashLoaded extends AEFModule implements Consumer<ScheduledTask
             int count = 0;
 
             if (onlyTileEntities) {
-                for (BlockState tileEntity : chunk.getTileEntities()) {
+                for (BlockState tileEntity : chunk.getTileEntities(false)) {
                     if (storageTypes.contains(tileEntity.getType())) {
                         count++;
                         if (count > stashCount) {


### PR DESCRIPTION
Since `tileEntity` here is for read-only, it's faster and better not copy snapshots of it. And it's good for if there are tons of chests in the stash.